### PR TITLE
Bug 97806 - add workflow for vm migration, nfsaccess and others

### DIFF
--- a/NfsAccess.ps1
+++ b/NfsAccess.ps1
@@ -1,0 +1,123 @@
+<#
+The MIT License (MIT)
+
+Copyright © 2023 Tintri by DDN, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+
+<#
+  This script demonstrates configurtion of NFS access on vmstore shares.
+  
+  The code example/script provided here is for reference only to illustrate
+  sample workflows and may not be appropriate for use in actual operating
+  environments. 
+#> 
+Param(
+  [string] $tsvr1_name,     # source tintri server (e.g. ts814.acme.com )
+  [string] $tsvr1_username, #  source tintri server web user (e.g. admin)
+  [string] $tsvr1_password, #  source tintri server password (e.g. Passw0rd!)
+  [string] $tsvr2_name,     # second tintri server (e.g. ts882.acme.com )
+  [string] $tsvr2_username, #  second tintri server web user (e.g. admin)
+  [string] $tsvr2_password  #  second tintri server password (e.g. Passw0rd!)
+)
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Input parameters"
+write-output "--------------------------------------------------------------------------"
+
+write-output "Tintri Servers src:$tsvr1_name second:$tsvr2_name"
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Connect to Tintri storage servers"
+write-output "--------------------------------------------------------------------------"
+
+Write-Output ">>> Import the Tintri Powershell Toolkit module.`n"
+if ($psEdition -ne "Core") { $tpsEdition = "" } else { $tpsEdition = $psEdition }
+Import-Module -force "C:\Program Files\TintriPS$($tpsEdition)Toolkit\TintriPS$($tpsEdition)Toolkit.psd1"
+
+
+Write-Output ">>> Connect to initial tintri server $source_tsvr_name"
+disconnect-TintriServer -all -ea SilentlyContinue | out-null
+($srv1 = Connect-TintriServer -Server $tsvr1_name -UserName $tsvr1_username -Password $tsvr1_password -wa:SilentlyContinue) | fl
+
+Write-Output ">>> Connect to second tintri server $second_tsvr_name.`n"
+($svr2 = Connect-TintriServer -Server $tsvr2_name -UserName $tsvr2_username -Password $tsvr2_password -wa:SilentlyContinue) | fl
+
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Set specific access with multiple NFS mount points at once"
+write-output "--------------------------------------------------------------------------"
+
+Set-TintriDatastoreNfsAccess -svr $srv1 -ClientIpHigh 172.255.255.255,200.200.100.252,172.255.255.255 -ClientIpLow 172.0.0.0,10.0.0.0,172.0.0.0 `
+          -UseAllVmstoreDataIps -SubMount /tintri,/tintri,/tintri/dssub-nfs100
+Get-TintriDatastoreNfsAccess -svr $srv1  | select IsEnabled -expand Configs | fl
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Reconfigure access on existing datastore IP range"
+write-output "--------------------------------------------------------------------------"
+
+$ds = Get-TintriDatastore -TintriServer $srv1
+$ds.NfsAccesses.Configs[0].ClientIpHigh = "200.200.100.252"
+$ds | Set-TintriDatastoreNfsAccess
+Get-TintriDatastoreNfsAccess -svr $srv1  | select IsEnabled -expand Configs | fl
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Add specific NFS access"
+write-output "--------------------------------------------------------------------------"
+
+Set-TintriDatastoreNfsAccess -AccessTask Add -ClientIpHigh 10.205.82.254 -ClientIpLow 10.205.82.100 -UseAllVmstoreDataIps -SubMount /tintri
+Get-TintriDatastoreNfsAccess | select IsEnabled -expand Configs | fl
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Remove specific NFS access"
+write-output "--------------------------------------------------------------------------"
+
+$n = Set-TintriDatastoreNfsAccess -AccessTask Remove -ClientIpHigh 10.205.82.254,200.200.100.252 -ClientIpLow 10.205.82.100,10.0.0.0  `
+                    -VmstoreIpHigh 255.255.255.255,255.255.255.255  -VmstoreIpLow 0.0.0.0,0.0.0.0  -SubMount /tintri,/tintri
+Get-TintriDatastoreNfsAccess | select IsEnabled -expand Configs | fl
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Mangage NFS access on multiple servers (using first server as a NFS access template)"
+write-output "--------------------------------------------------------------------------"
+
+$nfsTemplate = Set-TintriDatastoreNfsAccess -svr $srv1 -ClientIpHigh 172.255.255.255,200.200.100.252,172.255.255.255 -ClientIpLow 172.0.0.0,10.0.0.0,172.0.0.0 `
+          -UseAllVmstoreDataIps -SubMount /tintri,/tintri,/tintri/dssub-nfs100
+
+Get-TintriServerSession -all | Set-TintriDatastoreNfsAccess -NfsAccess $nfsTemplate
+Get-TintriDatastoreNfsAccess -SearchAllTintriServers  | select ApplianceHostName,IsEnabled -expand Configs | select ApplianceHostName,IsEnabled,Submount,ClientIpLow,ClientIpHigh,VmstoreIpLow,VmstoreIpHigh | ft
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Disable specific IP range NFS access on each server (i.e. allow all IPs to access)"
+write-output "--------------------------------------------------------------------------"
+
+foreach ($svr in Get-TintriServerSession -all)
+{
+	Set-TintriDatastoreNfsAccess -TintriServer $svr -NfsIpAccessEnabled $false | out-null
+}
+Get-TintriDatastoreNfsAccess -SearchAllTintriServers | fl 
+
+
+

--- a/NotifyConfiguration.ps1
+++ b/NotifyConfiguration.ps1
@@ -1,0 +1,138 @@
+<#
+The MIT License (MIT)
+
+Copyright © 2023 Tintri by DDN, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+
+<#
+  This script demonstrates configurtion of notification-alert policies and thresholds.
+  
+  The code example/script provided here is for reference only to illustrate
+  sample workflows and may not be appropriate for use in actual operating
+  environments. 
+#> 
+Param(
+  [string] $tsvr1_name,     # source tintri server (e.g. ts814.acme.com )
+  [string] $tsvr1_username, #  source tintri server web user (e.g. admin)
+  [string] $tsvr1_password, #  source tintri server password (e.g. Passw0rd!)
+  [string] $tsvr2_name,     # second tintri server (e.g. ts882.acme.com )
+  [string] $tsvr2_username, #  second tintri server web user (e.g. admin)
+  [string] $tsvr2_password  #  second tintri server password (e.g. Passw0rd!)
+)
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Input parameters"
+write-output "--------------------------------------------------------------------------"
+
+write-output "Tintri Servers src:$tsvr1_name second:$tsvr2_name"
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Connect to Tintri storage servers"
+write-output "--------------------------------------------------------------------------"
+
+Write-Output ">>> Import the Tintri Powershell Toolkit module.`n"
+if ($psEdition -ne "Core") { $tpsEdition = "" } else { $tpsEdition = $psEdition }
+Import-Module -force "C:\Program Files\TintriPS$($tpsEdition)Toolkit\TintriPS$($tpsEdition)Toolkit.psd1"
+
+
+Write-Output ">>> Connect to initial tintri server $source_tsvr_name"
+Disconnect-TintriServer -all -ea SilentlyContinue | Out-Null
+($srv1 = Connect-TintriServer -Server $tsvr1_name -UserName $tsvr1_username -Password $tsvr1_password -wa:SilentlyContinue) | fl
+
+Write-Output ">>> Connect to second tintri server $second_tsvr_name.`n"
+($svr2 = Connect-TintriServer -Server $tsvr2_name -UserName $tsvr2_username -Password $tsvr2_password -wa:SilentlyContinue) | fl
+
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Create new notification policies"
+write-output "--------------------------------------------------------------------------"
+
+Get-TintriServerSession -all | Get-TintriNotifyPolicy | Remove-TintriNotifyPolicy  -confirm:$false -ea SilentlyContinue | Out-Null
+($np = New-TintriNotifyPolicy -Name policy1 -Description policy1-description -alertid LOG-ARPING-0001,LOG-FREESPACE-0001 -NotificationEnable) | fl 
+($np2 = New-TintriNotifyPolicy -Name policy2 -Description policy2-description -alertid LOG-HYPERV-0035 -NotificationEnable -EmailNotification -SnmpTrapEnable) | fl 
+($np3 = New-TintriNotifyPolicy -svrHost $tsvr2_name -Name policy3 -Description policy3-description -alertid LOG-SMB-2112) | fl 
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Get notificaiton policies by AlertIds(all servers), by policy object, and by UUID"
+write-output "--------------------------------------------------------------------------"
+
+Get-TintriNotifyPolicy -SearchAllTintriServers -alertid LOG-ARPING-0001,LOG-FREESPACE-0001,LOG-SMB-2112
+$np | Get-TintriNotifyPolicy
+Get-TintriNotifyPolicy -Uuid $np.Uuid.UuId -TintriServer $svr2
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Remove notification policy by AlertId, by notify object, and by UUID"
+write-output "--------------------------------------------------------------------------"
+
+Remove-TintriNotifyPolicy -alertid LOG-ARPING-0001,LOG-FREESPACE-0001 -confirm:$false
+$np2 | Remove-TintriNotifyPolicy -confirm:$false
+$svr2 | Remove-TintriNotifyPolicy -Uuid $np3.Uuid.Uuid -confirm:$false
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Manage multiple servers, set the same policy on each server"
+write-output "--------------------------------------------------------------------------"
+
+$npTemplate = New-TintriNotifyPolicy -Name policyMaster -Description policyMaster-description -alertid LOG-ARPING-0001,LOG-FREESPACE-0001,LOG-CERT-0002 -NotificationEnable
+foreach ($svr in Get-TintriServerSession -all)
+{
+	Get-TintriNotifyPolicy -TintriServer $svr | Remove-TintriNotifyPolicy -TintriServer $svr -confirm:$false -ea SilentlyContinue | Out-Null
+	$npTemplate | New-TintriNotifyPolicy -TintriServer $svr | fl
+}
+
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Set alert thresholds, by type, and by threshold"
+write-output "--------------------------------------------------------------------------"
+
+Set-TintriAlertThreshold -ThresholdType UsedPercentAlertLowThreshold -Value 80
+$thold = Get-TintriAlertThreshold -ThresholdType ReservesUsedPercentAlertThreshold
+$thold.Value = 50
+$thold | Set-TintriAlertThreshold
+ 
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Get alert thresholds, by type, and by threshold"
+write-output "--------------------------------------------------------------------------"
+
+Get-TintriAlertThreshold -ThresholdType UsedPercentAlertLowThreshold
+$thold | Get-TintriAlertThreshold
+Get-TintriAlertThreshold -Threshold $thold
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Clear alert thresholds to their default values"
+write-output "--------------------------------------------------------------------------"
+
+Clear-TintriAlertThreshold -ThresholdType UsedPercentAlertLowThreshold
+Clear-TintriAlertThreshold -Threshold $thold
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Manage mutlple servers with a template threshold"
+write-output "--------------------------------------------------------------------------"
+
+$tholdTemplate = Set-TintriAlertThreshold -ThresholdType UsedPercentAlertLowThreshold -Value 75
+Get-TintriServerSession -all | Clear-TintriAlertThreshold -Threshold $tholdTemplate
+Get-TintriServerSession -all | Set-TintriAlertThreshold -Threshold $tholdTemplate
+
+

--- a/Workflow/Workflow_VmMigrate.ps1
+++ b/Workflow/Workflow_VmMigrate.ps1
@@ -1,0 +1,181 @@
+<#
+The MIT License (MIT)
+
+Copyright © 2023 Tintri by DDN, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+
+<#
+  This script demonstrates the VM migration workflow.
+  
+  The code example/script provided here is for reference only to illustrate
+  sample workflows and may not be appropriate for use in actual operating
+  environments. 
+#> 
+Param(
+  [string] $source_tsvr_name,
+  [string] $source_tsvr_username,
+  [string] $source_tsvr_password,
+  [string] $target_tsvr_name,
+  [string] $target_tsvr_username,
+  [string] $target_tsvr_password,
+  [string] $vc_viserver,
+  [string] $vc_viusername,
+  [string] $vc_vipassword,
+  [string] $source_datastore, 
+  [string] $target_datastore, 
+  [string] $source_esx_host,
+  [string] $output_dir
+)
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Input parameters"
+write-output "--------------------------------------------------------------------------"
+
+$vmw_pfx = "vmw_VMotionMigrate"
+$vm_max = 9
+write-output "Tintri Servers src:$source_tsvr_name dst:$target_tsvr_name"
+write-output "Datastores:    src:$source_datastore dst:$target_datastore"
+write-output "Esx Host:      $source_esx_host"
+write-output "V-Center:      $vc_viserver"
+write-output "Output:        $output_dir"
+write-output "VM prefix:     $vmw_pfx"
+write-output "VM count:      $vm_max"
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Connect to servers (source-destination-vcenter)"
+write-output "--------------------------------------------------------------------------"
+
+Write-Output ">>> Import the vmware powercli module.`n"
+import-module VMware.VimAutomation.Core
+
+Write-Output ">>> Import the Tintri Powershell Toolkit module.`n"
+if ($psEdition -ne "Core") { $tpsEdition = "" } else { $tpsEdition = $psEdition }
+Import-Module -force "C:\Program Files\TintriPS$($tpsEdition)Toolkit\TintriPS$($tpsEdition)Toolkit.psd1"
+
+Write-Output ">>> Connect to a tintri server $source_tsvr_name"
+($src = Connect-TintriServer -Server $source_tsvr_name -UserName $source_tsvr_username -Password $source_tsvr_password -wa:SilentlyContinue) | fl
+
+Write-Output ">>> Connect to a tintri server $target_tsvr_name.`n"
+($dst = Connect-TintriServer -Server $target_tsvr_name -UserName $target_tsvr_username -Password $target_tsvr_password -wa:SilentlyContinue) | fl
+
+Write-Output ">>> Connect to a VI server $vc_viserver.`n"
+if ($global:DefaultVIServers) { Disconnect-VIServer * -Force -confirm:$false -ea SilentlyContinue | out-null }
+($vc_srv = Connect-VIServer -Server $vc_viserver -User $vc_viusername -Password $vc_vipassword) | Format-List
+
+Write-Output ">>> Create output dir and clean previous test run.`n"
+new-item -path $output_dir -type directory -ea SilentlyContinue | out-null
+Remove-Item "$output_dir\*.log" -ea SilentlyContinue -confirm:$false | out-null
+
+
+
+write-output "--------------------------------------------------------------------------"
+write-Output ">>> Removing previous test virtual machines on $($src.HostNameOrIp) with prefix[$vmw_pfx]"
+write-output "--------------------------------------------------------------------------"
+
+$vmList = New-Object System.Collections.ArrayList
+for ($vmIdx = 0; $vmIdx -lt $vm_max; $vmIdx++)
+{
+    $vmName= $vmw_pfx + '_{0:X3}' -f $vmidx
+    write-output "Removing pre-existing test virtual machine:$vmName"
+    $vmw = Get-VM -Name $vmname -ea SilentlyContinue
+    if ($vmw)
+    {
+      Remove-VM -DeletePermanently -VM $vmw -Confirm:$false -ea SilentlyContinue | out-null
+      write-output "Removed vm:$($vmw.name)"
+    }
+}
+#start from clean slate on VMs, this will remove synthetic VM snapshots
+write-output "Remove existing snapshots to start from clean slate on vms: [$vmw_pfx] `n"
+Get-Tintrivm -Refresh -searchall | Where {$_.vmware.name -like $vmw_pfx+"*"} | Remove-TintriVMSnapshot -Force -ea SilentlyContinue | Out-Null
+Get-Tintrivm -Refresh -searchall | Out-Null
+
+write-output "--------------------------------------------------------------------------"
+write-Output ">>> Creating virtual machines on $($src.HostNameOrIp) with prefix[$vmw_pfx]"
+write-output "--------------------------------------------------------------------------"
+
+for ($vmIdx = 0; $vmIdx -lt $vm_mx; $vmIdx++)
+{
+    $vmName=$vmw_pfx + '_{0:X3}' -f $vmidx
+      write-output "Adding vm:$vmName"
+    ($vmW = New-VM -Name $vmName -Datastore $source_datastore -VMHost $source_esx_host -DiskMB 512 -MemoryMB 512 -DiskStorageFormat Thin -ea Continue) | out-null
+    if ($vmW)
+    {
+        $vmList.Add($vmW) | out-null
+        write-output "Added vm:$($vmW.name)"
+    }
+}
+
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Get source virtual machines on $($src.HostNameOrIp) with prefix[$vmw_pfx]"
+write-output "--------------------------------------------------------------------------"
+$vms = Get-Tintrivm -Refresh -svr $src | Where {$_.islive -and $_.vmware.name -like $vmw_pfx+"*"} | Sort-Object -property @{Expression={$_.vmware.name}} 
+$vms | select-object -expand vmware | Select-Object name,storagecontainers | Format-Table -autosize
+if ($vms.count -ne $vm_max)
+{
+    throw "Failed to find expected number of virtual machines"
+}
+
+write-output "--------------------------------------------------------------------------"
+write-output ">>> Generate new source VM snapshots"
+write-output "--------------------------------------------------------------------------"
+$vms = Get-Tintrivm -Refresh -svr $src | Where {$_.islive -and $_.vmware.name -like $vmw_pfx+"*"} | Sort-Object -property @{Expression={$_.vmware.name}} 
+$snaps = $vms | Get-TintriVMSnapshot
+$snaps | Select-Object Description,consistency,createtime,vmname | Format-Table -autosize
+
+
+write-output "==========================================="
+write-output ">>> Starting vmotion virtual machine migration on $($src.HostNameOrIp)"
+write-output "  vm.count: $($vms.Count)"
+write-output "==========================================="
+
+
+$jobs = @()
+$command = { param($vmSrc, $vmDst, $vmName, $destDs)
+                import-module TintriPsCoreToolkit
+                Connect-TintriServer $vmSrc.HostNameOrIp $using:source_tsvr_username $using:source_tsvr_password -wa:SilentlyContinue | Out-Null
+                Connect-TintriServer $vmDst.HostNameOrIp $using:target_tsvr_username $using:target_tsvr_password -wa:SilentlyContinue | Out-Null
+                $outfile = ($using:output_dir+"\$vmName-"+(get-date).ToString("yyyyMMddTHHmmss")+".log")
+                write-host ">>> Start-TintriVMMigration -svr $vmSrc.HostNameOrIp -svrdst $vmDst.HostNameOrIp -Name $vmName -datastore $destDs -confirm:$false -out $outfile"
+                Start-TintriVMMigration -svr $vmSrc -svrdst $vmDst -Name $vmName -datastore $destDs -passThru -confirm:$false -verbose | out-file $outfile
+            }
+$jobs = $vms | ForEach-Object { start-ThreadJob -name ($_.vmware.name+"-migrate-job") -scriptblock $command -ThrottleLimit 7 -ArgumentList $src, $dst, $_.vmware.name,$target_datastore}
+
+write-output "==========================================="
+write-output ">>> Wait for JOBS(RELOCATE_VM) started on $($src.HostNameOrIp)"
+write-output "  Started job.Count:[$($jobs.Count)] $($jobs[-1].name)"
+write-output "==========================================="
+$jobs | Format-Table -autosize
+$jobs | Receive-Job -wait
+
+    
+write-output "==========================================="
+write-output ">>> Show tasks(RELOCATE_VM) on source $($src.HostNameOrIp):"
+write-output "==========================================="
+$tasks = Get-TintriTaskStatus -TintriServer $src | Where {$_.Type -eq "RELOCATE_VM" } | sort-object -property LastUpdatedTime
+$tasks | Select-Object state,Type,JobDone,ProgressDescription,ProgressPercent -expand Uuid | select Type,JobDone,Uuid,ProgressDescription,ProgressPercent,State | Format-Table -autosize    
+
+
+write-output "==========================================="
+write-output ">>> Show start-VMMigration output captured in logs:"
+write-output "==========================================="
+Get-ChildItem $output_dir | Get-Content

--- a/Workflow/Workflow_VmMigrate.ps1
+++ b/Workflow/Workflow_VmMigrate.ps1
@@ -150,10 +150,10 @@ $snaps = $vms | Get-TintriVMSnapshot
 $snaps | Select-Object Description,consistency,createtime,vmname | Format-Table -autosize
 
 
-write-output "==========================================="
+write-output "--------------------------------------------------------------------------"
 write-output ">>> Starting vmotion virtual machine migration on $($src.HostNameOrIp)"
 write-output "  vm.count: $($vms.Count)"
-write-output "==========================================="
+write-output "--------------------------------------------------------------------------"
 
 $jobs = @()
 $command = { param($vmSrc, $vmDst, $vmName, $destDs)
@@ -168,22 +168,22 @@ $command = { param($vmSrc, $vmDst, $vmName, $destDs)
 $jobs = $vms | ForEach-Object { start-ThreadJob -name ($_.vmware.name+"-migrate-job") -scriptblock $command -ThrottleLimit 7 -ArgumentList $src, $dst, $_.vmware.name,$target_datastore}
 
 
-write-output "==========================================="
+write-output "--------------------------------------------------------------------------"
 write-output ">>> Wait for JOBS(RELOCATE_VM) started on $($src.HostNameOrIp)"
 write-output "  Started job.Count:[$($jobs.Count)] $($jobs[-1].name)"
-write-output "==========================================="
+write-output "--------------------------------------------------------------------------"
 $jobs | Format-Table -autosize
 $jobs | Receive-Job -wait
 
     
-write-output "==========================================="
+write-output "--------------------------------------------------------------------------"
 write-output ">>> Show tasks(RELOCATE_VM) on source $($src.HostNameOrIp):"
-write-output "==========================================="
+write-output "--------------------------------------------------------------------------"
 $tasks = Get-TintriTaskStatus -SearchAllTintriServers | Where {$_.Type -eq "RELOCATE_VM" } | sort-object -property LastUpdatedTime
 $tasks | Select-Object state,Type,JobDone,ProgressDescription,ProgressPercent -expand Uuid | select Type,JobDone,Uuid,ProgressDescription,ProgressPercent,State | Format-Table -autosize    
 
 
-write-output "==========================================="
+write-output "--------------------------------------------------------------------------"
 write-output ">>> Show start-VMMigration output captured in logs:"
-write-output "==========================================="
+write-output "--------------------------------------------------------------------------"
 Get-ChildItem $output_dir | Get-Content


### PR DESCRIPTION
Root Cause :  Need to give examples of vmotion VM Migration of multiple VMs at once, nfs access, and others for release
Proposed Fix : This provides a way to generate vms, add snapshots, show that they migrate, and see the resulting tasks and migration output. It also add samples for setting nfs mount ip access
Testing Done : Tested with the below parameters
Note for QA : Test this on your own setups.
